### PR TITLE
Include build version in file name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <!--suppress ALL -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <name>ChatFeelings</name>
+    <name>ChatFeelings-${project.version}</name>
     <groupId>com.zachduda</groupId>
     <artifactId>chatfeelings</artifactId>
     <url>https://zachduda.com/chatfeelings</url>


### PR DESCRIPTION
This feature will enable users to **easily identify the version of the plugin** they've downloaded, rather than resorting to commands like **/version <plugin>** for verification.